### PR TITLE
Path Not Found Error on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,9 +72,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             db_file = format!("{}/urls.txt", db_dir);
         }
         whoami::Platform::Windows => {
-            let home_dir = format!("C:\\Users\\{}", whoami::username());
-            let db_dir = format!("{}\\userrecon-rs", home_dir);
-            let db_file = format!("{}\\urls.txt", db_dir);
+            home_dir = format!("C:\\Users\\{}", whoami::username());
+            db_dir = format!("{}\\userrecon-rs", home_dir);
+            db_file = format!("{}\\urls.txt", db_dir);
         }
         _ => {}
     }


### PR DESCRIPTION
- Fix path not found on windows (remove var redeclaration)

<kbd>
  <img src="https://user-images.githubusercontent.com/51419598/164372108-71b03518-9538-44b4-9d75-7aebda551037.png">
</kbd>

<br /><br />

- There's an error on match closure/block when targeting windows platform:

```rs
// Declare path variables
let mut home_dir = String::new();
let mut db_dir = String::new();
let mut db_file = String::new();

whoami::Platform::Windows => {
  // Path variables redeclarations by using `let` again
  let home_dir = format!("C:\\Users\\{}", whoami::username());
  let db_dir = format!("{}\\userrecon-rs", home_dir);
  let db_file = format!("{}\\urls.txt", db_dir);
}
```

- On Linux there's no redeclaration:

```rs
// Declare path variables
let mut home_dir = String::new();
let mut db_dir = String::new();
let mut db_file = String::new();

whoami::Platform::Linux => {
  // Just assign without redeclaration
  home_dir = format!("/home/{}/", whoami::username());
  db_dir = format!("{}/.config/userrecon-rs", home_dir);
  db_file = format!("{}/urls.txt", db_dir);
}
```

> Ps. Rust newbie here, let me know if I'm missing something, thx